### PR TITLE
cpp/tokens-fungible/RootTokenContract.cpp delete lines 89,90 for cance…

### DIFF
--- a/cpp/tokens-fungible/RootTokenContract.cpp
+++ b/cpp/tokens-fungible/RootTokenContract.cpp
@@ -53,8 +53,6 @@ public:
                        TokensType tokens, WalletGramsType grams) {
     check_owner();
     require(total_granted_ + tokens <= total_supply_, error_code::not_enough_balance);
-    require((pubkey == 0 and internal_owner != 0) or (pubkey != 0 and internal_owner == 0),
-            error_code::define_pubkey_or_internal_owner);
 
     tvm_accept();
 

--- a/cpp/tokens-fungible/RootTokenContract.cpp
+++ b/cpp/tokens-fungible/RootTokenContract.cpp
@@ -86,8 +86,6 @@ public:
     auto value_gr = int_value();
     tvm_rawreserve(std::max(start_balance_.get(), tvm_balance() - value_gr()), rawreserve_flag::up_to);
 
-    require((pubkey == 0 and internal_owner != 0) or (pubkey != 0 and internal_owner == 0),
-            error_code::define_pubkey_or_internal_owner);
 
     std::optional<address> owner_addr;
     if (internal_owner)
@@ -234,4 +232,3 @@ DEFINE_JSON_ABI(IRootTokenContract, DRootTokenContract, ERootTokenContract);
 
 // ----------------------------- Main entry functions ---------------------- //
 DEFAULT_MAIN_ENTRY_FUNCTIONS_TMPL(RootTokenContract, IRootTokenContract, DRootTokenContract, ROOT_TIMESTAMP_DELAY)
-


### PR DESCRIPTION
cpp/tokens-fungible/RootTokenContract.cpp delete lines 89,90 for cancel the requirement of zero pubkey when the internal owner is specified. It add possibiliyty for internal_owner create more then only one empty wallet